### PR TITLE
Specification/loop invariant 012 cyclic

### DIFF
--- a/src/012_cyclic/main.whiley
+++ b/src/012_cyclic/main.whiley
@@ -74,7 +74,8 @@ ensures buf is EmptyBuffer ==> r :
 public function toString(Buffer b) -> ascii::string:
     ascii::string r = "["
     int i = 0
-    while i < |b.data|:
+    while i < |b.data|
+    where 0 <= i && i <= |b.data|:
         if i != 0:
             r = ascii::append(r,", ")
         if i == b.rpos:


### PR DESCRIPTION
To fix failing travis build as shown in #23.
```
compile:
     [echo] COMPILING: 012_cyclic
     [echo] ===================================
     [echo] /home/travis/build/Whiley/WyBench
      [wyc] /home/travis/build/Whiley/WyBench/src/012_cyclic/main.whiley:84: index out of bounds (negative)
      [wyc]         r = ascii::append(r,ascii::toString(b.data[i]))
      [wyc]                                             ^^^^^^^^^
```