### PR TITLE
Fix indexoutofbounds for parseConfig in 102_conway.

### DIFF
--- a/src/102_conway/main.whiley
+++ b/src/102_conway/main.whiley
@@ -95,7 +95,8 @@ function isAlive(Board board, int row, int col) -> int:
 // Parser
 // ============================================
 
-function parseConfig(int[] data) -> (Board board, int nIterations):
+function parseConfig(int[] data) -> (Board board, int nIterations)
+requires |data| >= 3:
     //
     int niters = data[0]
     int cols = data[1]


### PR DESCRIPTION
Due to data being accessed without checking the length of the array.

Closes #32 