### PR TITLE
Fix specification for the LinkedList so it is no longer cyclic.

### DIFF
--- a/src/032_arrlist/main.whiley
+++ b/src/032_arrlist/main.whiley
@@ -14,7 +14,7 @@ ensures (r.data == d) && (r.next == n):
 
 property valid(LinkedList l, Link n, int i)
 // All next links go "down", cannot be cyclic or a "null"
-where (n.next < i) || (i == 0) || (n.next == |l.links|)
+where (n.next < i) || (i == 0 && n.next == |l.links|) || (n.next == |l.links|)
 
 type LinkedList is ({Link[] links, nat size} l)
 // Never more links than available space


### PR DESCRIPTION
The first element in the LinkedList will point to a 'null' value
which is the length of the list.

Now passes using QuickCheck for Whiley.

Closes #28 