### PR TITLE
Fix postcondition for the returned graph size.

### DIFF
--- a/src/008_scc/main.whiley
+++ b/src/008_scc/main.whiley
@@ -29,7 +29,7 @@ function addEdge(Digraph g, nat from, nat to) -> Digraph:
 
 // Ensure graph has sufficient capacity
 function resize(Digraph g, int size) -> (Digraph r)
-ensures |r| == size:
+ensures |r| > size || (size >= |g| && |r| == size):
     //
     if size >= |g|:
         // Graph smaller than required


### PR DESCRIPTION
The original graph could already be a bigger size than the size given so it should be a valid graph.
Otherwise, the graph is resized to be the same size specified.